### PR TITLE
Add /v2/backup+embed endpoints

### DIFF
--- a/pages/api/v2/backup/index.js
+++ b/pages/api/v2/backup/index.js
@@ -1,0 +1,28 @@
+import postgresClient from 'lib/providers/postgres-admin'
+
+async function exportChannel(slug) {
+	const res = await postgresClient.query('select * from channels where slug = $1', [slug])
+	return res.rows[0]
+}
+
+async function exportTracks(slug) {
+	const res = await postgresClient.query('select * from channel_tracks where slug = $1', [slug])
+	return res.rows
+}
+
+export default async function handler(req, res) {
+	const {slug} = req.query
+	if (!slug) {
+		return res.status(404).json({
+			message: 'Missing parameter `?slug=` for a channel slug',
+		})
+	}
+	try {
+		const channel = await exportChannel(slug)
+		const tracks = await exportTracks(slug)
+		return res.status(200).json({channel, tracks})
+	} catch (error) {
+		console.error(error)
+		return res.status(500).json({error: `Failed to back up @${slug}`,})
+	}
+}

--- a/pages/api/v2/embed/index.js
+++ b/pages/api/v2/embed/index.js
@@ -1,0 +1,52 @@
+import createDOMPurify from 'dompurify'
+import {JSDOM} from 'jsdom'
+
+export default function handler(req, res) {
+	const slug = req.query.slug
+
+	// Prevent XSS
+	const DOMPurify = createDOMPurify(new JSDOM('').window)
+	const safeSlug = DOMPurify.sanitize(slug)
+
+	if (!safeSlug)
+		return res.status(404).json({
+			message: 'Missing parameter `?slug=`',
+		})
+
+	res.status(200).send(getIframe(safeSlug))
+}
+
+const getIframe = (slug) => {
+	return `
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width">
+		<title>@${slug} | Radio4000</title>
+		<meta name="description" content="${slug}@r4-player">
+		<style>
+			html, body, radio4000-player {
+				height: 100% !important;
+			}
+			body {
+				margin: 0;
+			}
+		</style>
+	</head>
+	<body>
+
+		<r4-app
+			href="http://localhost:3001/api/v2/embed/"
+			single-channel="true"
+			channel=${slug}
+			cdn
+		></r4-app>
+
+		<script async type="module" src="https://cdn.jsdelivr.net/npm/@radio4000/components@latest/dist/r4.js"></script>
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@radio4000/components@latest/dist/r4.css" />
+
+	</body>
+</html>
+`
+}

--- a/pages/api/v2/index.js
+++ b/pages/api/v2/index.js
@@ -1,0 +1,5 @@
+export default function handler(req, res) {
+	res.status(200).json({
+		message: 'Welcome to the Radio4000 V2 API (this endpoint is for humans)',
+	})
+}


### PR DESCRIPTION
Adds `/v2/backup` and `/v2/embed` endpoints.

Embed renders r4-app in single mode instead of `<radio4000-player>`.

Backup returns a channel + its tracks (provided supabase limit is configured).

Related to #16 
Closes https://github.com/radio4000/sdk/issues/19