### PR TITLE
refactor .env by environment and use integration vercel/supabase

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,17 @@
+# Procedure: if using with vercel, fill as .env and copy/pase content on vercel UI
+FIREBASE_DATABASE_URL="https://radio4000.firebaseio.com"
+
+RADIO4000_CMS_URL="https://beta.radio4000.com"
+RADIO4000_API_URL="https://api.radio4000.com/api"
+RADIO4000_REPO_URL="https://github.com/radio4000/api-vercel"
+RADIO4000_APP_ICON_URL="https://assets.radio4000.com/icon.png"
+RADIO4000_PLAYER_SCRIPT_URL="https://cdn.jsdelivr.net/npm/radio4000-player/dist/radio4000-player.min.js"
+
+CLOUDINARY_URL="https://res.cloudinary.com/radio4000"
+
+# supabase (managed by integration with vercel)
+SUPABASE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im91cGd1ZGxrc3BzbXprbWVvdmxoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MTM0NTIwNzQsImV4cCI6MjAyOTAyODA3NH0.KAbKFBChJHtxTmOZM2pdeppIyNbcnQkEgSi6RA7OQdo"
+SUPABASE_URL="https://oupgudlkspsmzkmeovlh.supabase.co"
+
+# not managed by supabase/vercel (default)
+POSTGRES_PORT=5432

--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,3 @@
-# Procedure: if using with vercel, fill as .env and copy/pase content on vercel UI
-
 FIREBASE_DATABASE_URL="https://radio4000-staging.firebase.io"
 
 RADIO4000_CMS_URL="http://localhost:3000"

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,0 @@
-# Procedure: if using with vercel, fill as .env and copy/pase content on vercel UI
-
-FIREBASE_DATABASE_URL="https://radio4000-staging.firebase.io"
-
-RADIO4000_CMS_URL="http://localhost:3000"
-RADIO4000_API_URL="http://localhost:3001/api"

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,5 @@
+# copy as (PRIVATE) .env.local (and copy paste into vercel UI for new deploy)
+
 # media providers apis
 YOUTUBE_API_KEY=AIzaS[...]
 

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,18 @@
+# media providers apis
+YOUTUBE_API_KEY=AIzaS[...]
+
+# Firebase admin connection
+FIREBASE_SERVICE_ACCOUNT_PROJECT_ID="firebase-radio4000"
+FIREBASE_SERVICE_ACCOUNT_CLIENT_EMAIL="firebase-radio4000@firebase-radio4000.iam.gserviceaccount.com"
+# be sure to surround with simple quotes '' when adding to vercel (no "")
+FIREBASE_SERVICE_ACCOUNT_PRIVATE_KEY="'-----BEGIN PRIVATE KEY-----\nMIIEvQCBKcw[...]MufelMV0=\n-----END PRIVATE KEY-----\n'"
+
+
+# postgresql admin connection (not managed by cercel/supabase)
+POSTGRES_PORT=5432
+
+# managed by vercel/supabase integration
+POSTGRES_HOST=aws-0-eu-central-1.pooler.supabase.com
+POSTGRES_DATABASE=postgres
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=abcd1234

--- a/.gitignore
+++ b/.gitignore
@@ -24,10 +24,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
-.env
-.env*
-!.env.example
+# local env files (examples are kept)
+.env*.local
+!.env*.local.example
 
 # vercel
 .vercel

--- a/lib/config.js
+++ b/lib/config.js
@@ -32,11 +32,11 @@ const requiredEnvVars = {
 
 	'YOUTUBE_API_KEY': null,
 
-	'PGHOST': null,
-	'PGUSER': null,
-	'PGDATABASE': null,
-	'PGPASSWORD': null,
-	'PGPORT': null,
+	'POSTGRES_USER': null,
+	'POSTGRES_HOST': null,
+	'POSTGRES_PASSWORD': null,
+	'POSTGRES_DATABASE': null,
+	'POSTGRES_PORT': null,
 }
 
 /* assign env values to a config object */
@@ -74,7 +74,7 @@ Object.keys(config).forEach(configKey => {
 			value: configValue
 		})
 	}
-	if (configKey.startsWith('PG') && !configValue) {
+	if (configKey.startsWith('POSTGRES') && !configValue) {
 		console.error({
 			message: 'Missing required Radio4000@supabase/postgresql env variable',
 			variable: configKey,

--- a/lib/providers/postgres-admin.js
+++ b/lib/providers/postgres-admin.js
@@ -1,8 +1,23 @@
+import config from 'lib/config'
 import pg from 'pg'
+
+const {
+	POSTGRES_USER,
+	POSTGRES_HOST,
+	POSTGRES_PASSWORD,
+	POSTGRES_DATABASE,
+	POSTGRES_PORT,
+} = config
 
 // connect to postgresql
 // ENV vars are loaded by default
-const pool = new pg.Pool()
+const pool = new pg.Pool({
+	user: POSTGRES_USER,
+	host: POSTGRES_HOST,
+	database: POSTGRES_DATABASE,
+	password: POSTGRES_PASSWORD,
+	port: POSTGRES_PORT,
+})
 
 // the pool will emit an error on behalf of any idle clients
 // it contains if a backend error or network partition happens

--- a/package.json
+++ b/package.json
@@ -1,32 +1,32 @@
 {
-	"name": "radio4000-api",
-	"scripts": {
-		"dev": "next dev --port 3001",
-		"build": "next build",
-		"start": "next start",
-		"lint": "next lint"
-	},
-	"dependencies": {
-		"@supabase/supabase-js": "^1.29.1",
-		"dompurify": "^2.3.4",
-		"firebase-admin": "^10.0.1",
-		"jsdom": "^19.0.0",
-		"next": "12.0.7",
-		"node-fetch": "^3.1.0",
-		"pg": "^8.7.1",
-		"react": "17.0.2",
-		"react-dom": "17.0.2",
-		"uuid": "^8.3.2",
-		"youtubei": "^1.1.2"
-	},
-	"devDependencies": {
-		"eslint": "8.5.0",
-		"eslint-config-next": "12.0.7",
-		"firebase-tools": "^9.18.0",
-		"prettier": "^2.8.8",
-		"raw-loader": "^4.0.2"
-	},
-	"license": "aGPLv3",
+  "name": "radio4000-api",
+  "scripts": {
+    "dev": "next dev --port 3001",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^1.29.1",
+    "dompurify": "^2.3.4",
+    "firebase-admin": "^10.0.1",
+    "jsdom": "^19.0.0",
+    "next": "12.0.7",
+    "node-fetch": "^3.1.0",
+    "pg": "^8.7.1",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "uuid": "^8.3.2",
+    "youtubei": "^1.1.2"
+  },
+  "devDependencies": {
+    "eslint": "8.5.0",
+    "eslint-config-next": "12.0.7",
+    "firebase-tools": "^9.18.0",
+    "prettier": "^2.8.8",
+    "raw-loader": "^4.0.2"
+  },
+  "license": "aGPLv3",
   "prettier": {
     "semi": false,
     "singleQuote": true,

--- a/readme.md
+++ b/readme.md
@@ -85,10 +85,10 @@ This project uses the framework [Next.js](https://nextjs.org/).
 3. Open [http://localhost:3000](http://localhost:3000) with your browser to see the result of your changes
 
 ### Environment variables configuratoin
-The project requires access to a Supabase project (and Firebase realtime database for legacy or migration).
+The project requires access to a Supabase project (and Firebase realtime database for legacy or migration, as well as Youtube for automatic info fetching).
 
 To get the needed keys for local development, you can either:
-- [all] copy and fill the `.env.example` file into a `.env.local` file
+- [all] copy and fill the `.env.local.example` file into a `.env.local` file
 - [team] run `vercel env pull .env.local`.
 
 Docs: https://vercel.com/docs/concepts/projects/environment-variables


### PR DESCRIPTION
split the example env file into what next.js expects (`.env*` pattern etc.) and vercel (with supababe integration).

Also cleaned up the variables already in vercel (50 to < 10).

- psql supabase → vercel + supabase integratin
- firebase → manually
- youtue api → manually
- what is static, modular by next.js env files

docs:

- https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
- https://vercel.com/docs/cli/env
- https://vercel.com/integrations/supabase